### PR TITLE
Update package.json to include the readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.0",
   "description": "Syntax highlights JavaScript code with ANSI colors to be printed to the terminal.",
   "main": "cardinal.js",
+  "readme": "README.md",
   "scripts": {
     "test": "tap ./test/*.js",
     "demo": "node examples/highlight-string.js; node examples/highlight-self; node examples/highlight-self-hide-semicolons;"


### PR DESCRIPTION
This is required on npm 3, otherwise the attribute will be created with "readme": "ERROR: No README data found!"

(this is used in your replpad tests as well)