### PR TITLE
Update highlight-self-hide-semicolons example with opts object

### DIFF
--- a/examples/highlight-self-hide-semicolons.js
+++ b/examples/highlight-self-hide-semicolons.js
@@ -12,7 +12,7 @@ function highlight () {
   // For asynchronous highlighting use: highlightFile() - see highlight-self.js
   
   try {
-    var highlighted = cardinal.highlightFileSync(__filename, hideSemicolonsTheme);
+    var highlighted = cardinal.highlightFileSync(__filename, {theme: hideSemicolonsTheme});
     console.log(highlighted);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Looks like this was missed when changing `highlight` to accept opts object with `theme` key (instead of accepting the key directly). See commits 62333e7 and d4b7902.