### PR TITLE
add a simpler theme, and simplify configuration loading

### DIFF
--- a/bin/cdl.js
+++ b/bin/cdl.js
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 var cardinal = require('..')
   , utl = require('../utl')
-  , settings = require('../settings')
   , args = process.argv
-  , theme = settings.resolveTheme()
-  , opts = settings.getSettings()
   , highlighted
+  , options = require('rc')('cardinal', {theme: 'simple'})
+  , path = require('path')
   ;
 
-opts = opts || {};
-opts.theme = theme;
+if(options.theme) {
+  options.theme = require(path.join(__dirname, '..', 'themes', options.theme))
+}
 
 function usage() {
   var msg = [ 
@@ -24,51 +24,20 @@ function usage() {
   console.log(msg);
 }
 
-function highlightFile () {
+if(!process.stdin.isTTY) {
+  var data = ''
+  process.stdin.on('data', function (d) {
+    data += d
+  })
+  .on('end', function () {
+    process.stdout.write(cardinal.highlight(data, options))
+  })
+}
+else
   try {
-    highlighted = cardinal.highlightFileSync(args[2], opts);
-    console.log(highlighted);
+    console.log(cardinal.highlightFileSync(options._[0], options));
   } catch (e) {
     console.trace();
     console.error(e);
   }
-}
-
-// E.g., "cardinal myfile.js"
-if (args.length === 3) return highlightFile();
-
-var opt = args[3];
-
-// E.g., "cardinal myfile.js --nonum"
-if (opt && opt.indexOf('--') === 0 ) {
-  if ((/^--(nonum|noline)/i).test(opt)) opts.linenos = false;
-  else { 
-    usage();
-    return console.error('Unknown option: ', opt);
-  }
- 
-  return highlightFile();
-}
-
-
-// UNIX pipes e.g., "cat myfile.js | grep console | cardinal
-var stdin = process.stdin
-  , stdout = process.stdout;
-
-// line numbers don't make sense when we are printing line by line
-opts.linenos = false;
-
-stdin.setEncoding('utf-8');
-stdin.resume();
-stdin
-  .on('data', function (chunk) {
-    chunk.split('\n').forEach(function (line) {
-      try {
-        stdout.write(cardinal.highlight(line, opts) + '\n');
-      } catch (e) {
-        // line doesn't represent a valid js snippet and therefore cannot be parsed -> just print as is
-        stdout.write(line + '\n');
-      }
-    });
-  });
 

--- a/themes/simple.js
+++ b/themes/simple.js
@@ -1,0 +1,161 @@
+/*
+ * Copy this file and use it as a starting point for your custom cardinal color theme.
+ * Just fill in or change the entries for the tokens you want to color
+ * Keep in mind that more specific configurations override less specific ones.
+ */
+
+var colors = require('ansicolors');
+
+// Change the below definitions in order to tweak the color theme.
+module.exports = {
+
+    'Boolean': {
+      'true'   :  undefined
+    , 'false'  :  undefined
+    , _default :  undefined
+    }
+
+  , 'Identifier': {
+      _default: undefined
+    }
+
+  , 'Null': {
+      _default: undefined
+    }
+
+  , 'Numeric': {
+      _default: colors.magenta
+    }
+
+  , 'String': {
+      _default: colors.red
+    }
+
+ , 'Keyword': {
+/*      'break'       :  colors.cyan
+
+    , 'case'        :  colors.cyan
+    , 'catch'       :  colors.cyan
+    , 'class'       :  colors.cyan
+    , 'const'       :  colors.cyan
+    , 'continue'    :  colors.cyan
+
+    , 'debugger'    :  colors.cyan
+    , 'default'     :  colors.cyan
+    , 'delete'      :  colors.cyan
+    , 'do'          :  colors.cyan
+
+    , 'else'        :  colors.cyan
+    , 'enum'        :  colors.cyan
+    , 'export'      :  colors.cyan
+    , 'extends'     :  colors.cyan
+
+    , 'finally'     :  colors.cyan
+    , 'for'         :  colors.cyan
+    , 'function'    :  colors.cyan
+
+    , 'if'          :  colors.cyan
+    , 'implements'  :  colors.cyan
+    , 'import'      :  colors.cyan
+    , 'in'          :  colors.cyan
+    , 'instanceof'  :  colors.cyan
+    , 'interface'   :  colors.cyan
+    , 'let'         :  colors.cyan
+    , 'new'         :  colors.cyan
+
+    , 'package'     :  colors.cyan
+    , 'private'     :  colors.cyan
+    , 'protected'   :  colors.cyan
+    , 'public'      :  colors.cyan
+
+    , 'return'      :  colors.cyan
+    , 'static'      :  colors.cyan
+    , 'super'       :  colors.cyan
+    , 'switch'      :  colors.cyan
+
+    , 'this'        :  undefined
+    , 'throw'       :  colors.cyan
+    , 'try'         :  colors.cyan
+    , 'typeof'      :  colors.cyan
+
+    , 'var'         :  colors.cyan
+    , 'void'        :  colors.cyan
+
+    , 'while'       :  colors.cyan
+    , 'with'        :  colors.cyan
+    , 'yield'       :  colors.cyan
+    , */ _default      :  colors.cyan
+  }
+  , 'Punctuator': {
+      ';': undefined
+    , '.': undefined
+    , ',': undefined
+
+    , '{': colors.green
+    , '}': colors.green
+    , '(': colors.brightBlack
+    , ')': colors.brightBlack
+    , '[': colors.yellow
+    , ']': colors.yellow
+
+    , '<': undefined
+    , '>': undefined
+    , '+': undefined
+    , '-': undefined
+    , '*': undefined
+    , '%': undefined
+    , '&': undefined
+    , '|': undefined
+    , '^': undefined
+    , '!': undefined
+    , '~': undefined
+    , '?': undefined
+    , ':': undefined
+    , '=': undefined
+
+    , '<=': undefined
+    , '>=': undefined
+    , '==': undefined
+    , '!=': undefined
+    , '++': undefined
+    , '--': undefined
+    , '<<': undefined
+    , '>>': undefined
+    , '&&': undefined
+    , '||': undefined
+    , '+=': undefined
+    , '-=': undefined
+    , '*=': undefined
+    , '%=': undefined
+    , '&=': undefined
+    , '|=': undefined
+    , '^=': undefined
+    , '/=': undefined
+    , '=>': undefined
+    , '**': undefined
+
+    , '===': undefined
+    , '!==': undefined
+    , '>>>': undefined
+    , '<<=': undefined
+    , '>>=': undefined
+    , '...': undefined
+    , '**=': undefined
+
+    , '>>>=': undefined
+
+    , _default: undefined
+  }
+
+    // line comment
+  , Line: {
+     _default: colors.blue
+    }
+
+    /* block comment */
+  , Block: {
+     _default: colors.blue
+    }
+
+  , _default: undefined
+};


### PR DESCRIPTION
none of the included highlighting schemes worked on the xterm (the simplest terminal emulator)
screen shots here, https://github.com/tslide/tslide/pull/17#issuecomment-285998555

so I made a simpler theme that does work.

looks like
![cardinal_lightbg](https://cloud.githubusercontent.com/assets/259374/23840268/ca83b346-0808-11e7-9a22-60b77405d0ea.png)
or
![cardinal_darkbg](https://cloud.githubusercontent.com/assets/259374/23840270/cd51feca-0808-11e7-82cb-097a3d1ab4b2.png)

Also, when testing I found it that you could set the theme in a configuration file, but not via the command line. I switched to `rc` which simplified the code somewhat, and gives you a bunch of features for free:
(in order of fallback)
* accept `--theme theme` as cli option
* accept a local `./.cardinalrc` file in the current (or parent, etc) directory
* accept enviroment variables `cardinal__theme=theme` 
* accept `~/.cardinalrc`

If you are into the shift to `rc` there are some more files which could be cleaned up, settings etc, but I thought i'd check if these changes where wanted before doing all that stuff.