### PR TITLE
fix: malformed link in README TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   - [*highlightFileSync(fullPath[, opts])*](#highlightfilesyncfullpath-opts)
   - [*highlightFile(fullPath[, opts], callback)*](#highlightfilefullpath-opts-callback)
   - [opts](#opts)
-- [Examples ([*browse*](https://github.com/thlorenz/cardinal/tree/master/examples))](#examples-[browse]https://githubcom/thlorenz/cardinal/tree/master/examples)
+- [Examples](#examples-browse)
 
 
 ## Installation


### PR DESCRIPTION
Likely a bug by the document generator because there's a link in the `#Examples (browse)` header.